### PR TITLE
Change tumugi dependency version

### DIFF
--- a/tumugi-plugin-bigquery.gemspec
+++ b/tumugi-plugin-bigquery.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "tumugi", "~> 0.5.1"
+  spec.add_runtime_dependency "tumugi", ">= 0.5.1"
   spec.add_runtime_dependency "kura", "~> 0.2.17"
 
   spec.add_development_dependency 'bundler', '~> 1.11'


### PR DESCRIPTION
Change dependency from `~> 0.5.0` to `>= 0.5.0`, because plugin can run with future tumugi release, such as `0.6.0`.
