### PR TITLE
Change test ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.1.10
-- 2.2.5
-- 2.3.1
-- jruby-9.0.5.0
+  - 2.1
+  - 2.3.1
+  - jruby-9.1.2.0
+before_install:
+  - gem install bundler
+


### PR DESCRIPTION
- Use travis default version of ruby 2.1 to avoid set specific version
- Remove test on ruby 2.2 because it's not neccesary
- Update jruby to latest 9.1.2.0
- Install bundler before install, this is needed to avoid bundler version error on newer ruby version, like ruby-haed.
