### PR TITLE
Support service account application default auth

### DIFF
--- a/lib/tumugi/plugin/bigquery/client.rb
+++ b/lib/tumugi/plugin/bigquery/client.rb
@@ -13,18 +13,14 @@ module Tumugi
         def initialize(project_id: nil, client_email: nil, private_key: nil, private_key_file: nil)
           @project_id = project_id
 
-          if client_email.nil? && private_key.nil?
-            if private_key_file.nil?
-              raise Tumugi::Plugin::Bigquery::BigqueryError.new("You must provide 'private_key_file'", "No authentication info")
-            else
-              @client = Kura.client(private_key_file)
-              if @project_id.nil?
-                key = JSON.parse(File.read(private_key_file))
-                @project_id = key['project_id']
-              end
+          if client_email.nil? && private_key.nil? && !private_key_file.nil?
+            @client = Kura.client(private_key_file)
+            if @project_id.nil?
+              key = JSON.parse(File.read(private_key_file))
+              @project_id = key['project_id']
             end
           else
-            @client = Kura.client(@project_id, client_email, private_key)
+            @client = Kura.client("project_id" => @project_id, "client_email" => client_email, "private_key" => private_key)
           end
         rescue Kura::ApiError => e
           process_error(e)

--- a/lib/tumugi/plugin/bigquery/client.rb
+++ b/lib/tumugi/plugin/bigquery/client.rb
@@ -20,7 +20,11 @@ module Tumugi
               @project_id = key['project_id']
             end
           else
-            @client = Kura.client("project_id" => @project_id, "client_email" => client_email, "private_key" => private_key)
+            # This method call style is needed for jruby.
+            # JRuby cannot handle correctly if method using keyword hash and last hash argument.
+            # see https://bugs.ruby-lang.org/issues/7529
+            @client = Kura.client(project_id = { "project_id" => @project_id, "client_email" => client_email, "private_key" => private_key },
+                                  client_email = nil, private_key = nil, {http_options: {timeout: 60}})
           end
         rescue Kura::ApiError => e
           process_error(e)

--- a/test/plugin/bigquery/client_test.rb
+++ b/test/plugin/bigquery/client_test.rb
@@ -14,9 +14,11 @@ class Tumugi::Plugin::Bigquery::ClientTest < Test::Unit::TestCase
       client = Tumugi::Plugin::Bigquery::Client.new(credential)
       assert_equal(credential[:project_id], client.project_id)
       assert_received(Kura) do |o|
-        o.client("project_id"   => credential[:project_id],
-                 "client_email" => credential[:client_email],
-                 "private_key"  => credential[:private_key])
+        o.client(project_id = {
+                  "project_id"   => credential[:project_id],
+                  "client_email" => credential[:client_email],
+                  "private_key"  => credential[:private_key] },
+                  client_email=nil, private_key=nil, {:http_options=>{:timeout=>60}})
       end
     end
 
@@ -32,9 +34,11 @@ class Tumugi::Plugin::Bigquery::ClientTest < Test::Unit::TestCase
       client = Tumugi::Plugin::Bigquery::Client.new(project_id: credential[:project_id])
       assert_equal(credential[:project_id], client.project_id)
       assert_received(Kura) do |o|
-        o.client("project_id"   => credential[:project_id],
-                 "client_email" => nil,
-                 "private_key"  => nil)
+        o.client(project_id = {
+                  "project_id"   => credential[:project_id],
+                  "client_email" => nil,
+                  "private_key"  => nil },
+                  client_email=nil, private_key=nil, {:http_options=>{:timeout=>60}})
       end
     end
   end

--- a/test/plugin/bigquery/client_test.rb
+++ b/test/plugin/bigquery/client_test.rb
@@ -9,23 +9,32 @@ class Tumugi::Plugin::Bigquery::ClientTest < Test::Unit::TestCase
   end
 
   sub_test_case "#initialize" do
-    test 'auth by arguments' do
+    test "auth by arguments" do
       stub(Kura).client { |o| o }
       client = Tumugi::Plugin::Bigquery::Client.new(credential)
       assert_equal(credential[:project_id], client.project_id)
-      assert_received(Kura) { |o| o.client(credential[:project_id], credential[:client_email], credential[:private_key]) }
+      assert_received(Kura) do |o|
+        o.client("project_id"   => credential[:project_id],
+                 "client_email" => credential[:client_email],
+                 "private_key"  => credential[:private_key])
+      end
     end
 
-    test 'auth by private key file' do
+    test "auth by private key file" do
       stub(Kura).client { |o| o }
       client = Tumugi::Plugin::Bigquery::Client.new(private_key_file: 'test/data/key.json')
       assert_equal('myproject', client.project_id)
       assert_received(Kura) { |o| o.client('test/data/key.json') }
     end
 
-    test 'raise error when no auth info' do
-      assert_raise(Tumugi::Plugin::Bigquery::BigqueryError) do
-        Tumugi::Plugin::Bigquery::Client.new
+    test "auth by application default" do
+      stub(Kura).client { |o| o }
+      client = Tumugi::Plugin::Bigquery::Client.new(project_id: credential[:project_id])
+      assert_equal(credential[:project_id], client.project_id)
+      assert_received(Kura) do |o|
+        o.client("project_id"   => credential[:project_id],
+                 "client_email" => nil,
+                 "private_key"  => nil)
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,10 @@ Coveralls.wear!
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
+raise "ENV['PROJECT_ID'] must be set" unless ENV.key?('PROJECT_ID')
+raise "ENV['CLIENT_EMAIL'] must be set" unless ENV.key?('CLIENT_EMAIL')
+raise "ENV['PRIVATE_KEY'] must be set" unless ENV.key?('PRIVATE_KEY')
+
 require 'test/unit'
 require 'test/unit/rr'
 


### PR DESCRIPTION
https://developers.google.com/identity/protocols/application-default-credentials

Change of this PR is a little bit tricky, but this is a trick for dependency library `kura` to run following line of code.

https://github.com/nagachika/kura/blob/master/lib/kura/client.rb#L27
